### PR TITLE
Setup crud endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'rack-cors'
 gem 'fast_jsonapi'
 gem 'jwt_sessions'
 
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -21,6 +22,7 @@ group :development, :test do
   gem 'simplecov'
   gem 'faker'
   gem 'shoulda-matchers'
+  gem 'capybara'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,14 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.33.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -130,6 +138,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.2.1)
+    regexp_parser (1.7.1)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -172,6 +181,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -180,6 +191,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
+  capybara
   faker
   fast_jsonapi
   jwt_sessions

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::ItemsController < ApplicationController
   def index
     render json: ItemSerializer.new(Item.all)
   end
-
+  
   def show
     return render json: Error.not_found, status: :not_found if item?
 

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,40 @@
+class Api::V1::ItemsController < ApplicationController
+  def create
+    return render json: Error.missing_params, status: :bad_request if missing_params?
+
+    render json: ItemSerializer.new(Item.create(item_params)), status: :created
+  end
+
+  def index
+    render json: ItemSerializer.new(Item.all)
+  end
+
+  def show
+    return render json: Error.not_found, status: :not_found if item?
+
+    render json: ItemSerializer.new(Item.find(params[:id]))
+  end
+
+  def update
+    render json: ItemSerializer.new(Item.update(params[:id], item_params))
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    render json: ItemSerializer.new(item.delete)
+  end
+
+  private
+
+  def item_params
+    params.permit(:name, :price)
+  end
+
+  def missing_params?
+    params[:name].blank? || params[:price].blank?
+  end
+
+  def item?
+    Item.where(id: params[:id]).empty?
+  end
+end

--- a/app/controllers/api/v1/subscription_controller.rb
+++ b/app/controllers/api/v1/subscription_controller.rb
@@ -1,0 +1,26 @@
+class Api::V1::SubscriptionController < ApplicationController
+  def create
+    return render json: Error.missing_params, status: :bad_request if missing_params?
+
+    render json: SubscriptionSerializer.new(Subscription.create(subscription_params)), status: :created
+  end
+
+  def update
+    render json: SubscriptionSerializer.new(Subscription.update(params[:id], subscription_params))
+  end
+
+  def destroy
+    subscription = Subscription.find(params[:id])
+    render json: SubscriptionSerializer.new(subscription.delete)
+  end
+
+  private
+
+  def subscription_params
+    params.permit(:delivery_day, :subscription_type, :user_id)
+  end
+
+  def missing_params?
+    params[:subscription_type].blank? || params[:delivery_day].blank?
+  end
+end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::SubscriptionsController < ApplicationController
+  def index
+    render json: SubscriptionSerializer.new(Subscription.all)
+  end
+
+  def show
+    return render json: Error.not_found, status: :not_found if subscription?
+    render json: SubscriptionSerializer.new(Subscription.find(params[:id]))
+  end
+
+  private
+
+  def subscription?
+    Subscription.where(id: params[:id]).blank?
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,47 @@
+class Api::V1::UsersController < ApplicationController
+  def index
+    render json: UserSerializer.new(User.all)
+  end
+
+  def show
+    render json: UserSerializer.new(User.find(params[:id]))
+  end
+
+  def create
+    return render json: Error.missing_params, status: :bad_request if missing_params?
+    return render json: Error.mismatched_passwords, status: :bad_request unless passwords_match?
+    return render json: Error.same_email, status: :bad_request if email_in_use?
+
+    render json: UserSerializer.new(User.create(user_params)), status: :created
+  end
+
+  def update
+    
+    render json: UserSerializer.new(User.update(params[:id], user_params))
+  end
+
+  def destroy
+    user = User.find(params[:id])
+    render json: UserSerializer.new(user.delete)
+  end
+
+  private
+
+  def user_params
+    params.permit(:name, :email, :address, :password)
+  end
+
+  def missing_params?
+    params[:email].blank? || params[:name].blank? || 
+    params[:password_confirmation].blank? || params[:address].blank? ||
+    params[:password].blank?
+  end
+
+  def passwords_match?
+    params[:password] == params[:password_confirmation]
+  end
+
+  def email_in_use?
+    User.find_by(email: params[:email])
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -16,7 +16,6 @@ class Api::V1::UsersController < ApplicationController
   end
 
   def update
-    
     render json: UserSerializer.new(User.update(params[:id], user_params))
   end
 

--- a/app/poros/error.rb
+++ b/app/poros/error.rb
@@ -22,6 +22,11 @@ class Error
       create_error(message)
     end
 
+    def not_found
+      message = 'Oops, record not found'
+      create_error(message)
+    end
+
     def create_error(message)
       error = Error.new(message)
       ErrorSerializer.new(error)

--- a/app/poros/error.rb
+++ b/app/poros/error.rb
@@ -1,0 +1,30 @@
+class Error
+  attr_reader :id, :message
+
+  def initialize(message)
+    @id = nil
+    @message = message
+  end
+
+  class << self
+    def missing_params
+      message = 'Missing required fields'
+      create_error(message)
+    end
+
+    def mismatched_passwords
+      message = 'Whoops, these passwords do not match'
+      create_error(message)
+    end
+
+    def same_email
+      message = 'Email is already in use'
+      create_error(message)
+    end
+
+    def create_error(message)
+      error = Error.new(message)
+      ErrorSerializer.new(error)
+    end
+  end
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,4 @@
+class ErrorSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :message
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,4 @@
+class ItemSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name, :price
+end

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,0 +1,4 @@
+class SubscriptionSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :subscription_type, :delivery_day, :user_id
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :name, :email, :address
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, except: [:new]
+      resources :items, except: [:new]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :users, except: [:new]
+      resources :users, except: [:new] do
+        resources :subscription, only: [:create, :update, :destroy]
+      end
+      resources :subscriptions, only: [:index, :show]
       resources :items, except: [:new]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :users, except: [:new]
+    end
+  end
 end
+  

--- a/spec/requests/api/v1/users/item_request_spec.rb
+++ b/spec/requests/api/v1/users/item_request_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe 'Item requests' do
+  describe 'perform item crud' do
+    before(:each) do
+      @item_params = {"name": "Sourdough loaf", "price": 750 }
+      @item_params2 = {"name": "Croissant", "price": 450 }
+      @item = Item.create(@item_params)
+      @item2 = Item.create(@item_params2)
+    end
+
+    it 'create item request' do
+      post "/api/v1/items", params: @item_params
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+      
+      item_response = JSON.parse(response.body, symbolize_names: true)
+      expect(item_response[:data][:attributes][:name]).to eq('Sourdough loaf')
+    end
+
+    it 'raises error with missing item params' do
+      invalid_params = {"name": "Croissant"}
+      post '/api/v1/items', params: invalid_params
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+      expect(item_response[:data][:attributes][:message]).to eq('Missing required fields')
+    end
+
+    it 'can get all items' do
+      get '/api/v1/items' 
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+      expect(item_response[:data].length).to eq(2)
+    end
+
+    it 'can get one item' do
+      get "/api/v1/items/#{@item.id}"
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+      expect(item_response[:data][:attributes][:name]).to eq(@item.name)
+    end
+
+    it 'raises error if item not found' do
+      get "/api/v1/items/9029393"
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+      expect(item_response[:data][:attributes][:message]).to eq('Oops, record not found')
+    end
+
+    it 'can update an item' do
+      update_params = {"price": 150}
+      put "/api/v1/items/#{@item.id}", params: update_params
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+      expect(item_response[:data][:attributes][:price]).to eq(150)
+    end
+
+    it 'can delete an item' do
+      delete "/api/v1/items/#{@item.id}"
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+      expect(item_response[:data][:attributes][:name]).to eq(@item.name)
+      expect(Item.all.length).to eq(1)
+    end
+  end
+end

--- a/spec/requests/api/v1/users/user_request_spec.rb
+++ b/spec/requests/api/v1/users/user_request_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe "User Requests" do
+  describe 'perform user crud' do
+    before(:each) do
+      @user = User.create!(
+        email: 'john@example.com',
+        name: 'John Wick',
+        address: '900 Victoria St.',
+        password: '1234',
+        password_confirmation: '1234'
+      )
+
+      @user2 = User.create!(
+        email: 'nick@example.com',
+        name: 'Nick Wick',
+        address: '900 Scooter St.',
+        password: '1234',
+        password_confirmation: '1234'
+      )
+    end
+    it 'create user specs' do
+      user_params = {
+        "email": "zach@example.com",
+        "name": "Zach",
+        "address": "594 Humboldt St",
+        "password": "1234password",
+        "password_confirmation": "1234password"
+      }
+
+      post '/api/v1/users', params: user_params
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+      create_response = JSON.parse(response.body, symbolize_names: true)
+      expect(create_response[:data][:attributes][:email]).to eq("zach@example.com")
+    end
+
+    it 'create user error handling missing params' do
+      user_params = {
+        "email": "",
+        "name": "Zach",
+        "address": "594 Humboldt St",
+        "password": "1234password",
+        "password_confirmation": "1234password"
+      }
+      post '/api/v1/users', params: user_params.to_json
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      error_response = JSON.parse(response.body, symbolize_names: true)
+      expect(error_response[:data][:attributes][:message]).to eq("Missing required fields")
+    end
+
+    it 'create user error handling mismatched passwords' do
+      user_params = {
+        "email": "zach@example.com",
+        "name": "Zach",
+        "address": "594 Humboldt St",
+        "password": "1234password",
+        "password_confirmation": "1234password"
+      }
+      post '/api/v1/users', params: user_params.to_json
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      error_response = JSON.parse(response.body, symbolize_names: true)
+      expect(error_response[:data][:attributes][:message]).to eq("Missing required fields")
+    end
+
+    it 'create user error handling email in use' do
+      user_params = {
+        "email": "zach@example.com",
+        "name": "Zach",
+        "address": "594 Humboldt St",
+        "password": "1234password",
+        "password_confirmation": "1234password"
+      }
+      user = User.create!(user_params)
+
+      post '/api/v1/users', params: user_params
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      error_response = JSON.parse(response.body, symbolize_names: true)
+      expect(error_response[:data][:attributes][:message]).to eq('Email is already in use')
+    end
+
+    it 'can get a list of users' do
+      get '/api/v1/users'
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      users_response = JSON.parse(response.body, symbolize_names: true)
+      expect(users_response[:data].length).to eq(2)
+      expect(users_response[:data].first[:id].to_i).to eq(@user.id)
+    end
+
+    it 'can get one user by id' do
+      get "/api/v1/users/#{@user.id}"
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      user_response = JSON.parse(response.body, symbolize_names: true)
+      expect(user_response[:data][:id].to_i).to eq(@user.id)
+    end
+
+    it 'can update a user' do
+      update_params = {
+        "email": "zach@google.com"
+      }
+      put "/api/v1/users/#{@user.id}", params: update_params
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      user_response = JSON.parse(response.body, symbolize_names: true)
+      expect(user_response[:data][:attributes][:email]).to eq('zach@google.com')
+    end
+
+    it 'can delete a user' do
+      expect(User.all.length).to eq(2)
+      
+      delete "/api/v1/users/#{@user.id}"
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      
+      user_response = JSON.parse(response.body, symbolize_names: true)
+      expect(user_response[:data][:attributes][:id]) == @user.id
+      expect(User.all.length).to eq(1)
+    end
+  end
+end

--- a/spec/requests/subscriptions_request_spec.rb
+++ b/spec/requests/subscriptions_request_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe 'Subscriptions requests' do
+  describe 'subscriptions crud' do
+    before(:each) do
+      @user1 = User.create!(
+        email: 'john@example.com',
+        name: 'John Wick',
+        address: '900 Victoria St.',
+        password: '1234',
+        password_confirmation: '1234'
+      )
+
+      @user2 = User.create!(
+        email: 'johnathon@example.com',
+        name: 'John Wick',
+        address: '900 Victoria St.',
+        password: '1234',
+        password_confirmation: '1234'
+      )
+
+      subscription_params = {
+        subscription_type: 0,
+        delivery_day: "Monday",
+        user: @user1
+      }
+      @subscription = Subscription.create!(subscription_params)
+    end
+
+    it "create subscription spec" do
+      sub_params = {
+        "subscription_type": 0,
+        "delivery_day": "Monday"
+      }
+      post "/api/v1/users/#{@user2.id}/subscription", params: sub_params
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+      
+      sub_response = JSON.parse(response.body, symbolize_names: true)
+      expect(sub_response[:data][:attributes][:user_id]).to eq(@user2.id)
+
+      subscription = Subscription.last
+      expect(@user2.subscription).to eq(subscription)
+    end
+
+    it "create subscription error handling missing params" do
+      sub_params = {
+        "delivery_day": "Monday"
+      }
+
+      post "/api/v1/users/#{@user2.id}/subscription", params: sub_params
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      error_response = JSON.parse(response.body, symbolize_names: true)
+      expect(error_response[:data][:attributes][:message]).to eq("Missing required fields")
+    end
+
+    it "user can update subscription" do
+      subscription = @user1.subscription
+      update = { "subscription_type": 1 }
+      put "/api/v1/users/#{@user1.id}/subscription/#{subscription.id}", params: update
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      update_response = JSON.parse(response.body, symbolize_names: true)
+      expect(update_response[:data][:attributes][:subscription_type]).to eq(1)
+      user = User.find(@user1.id)
+      expect(user.subscription.subscription_type).to eq(1) 
+    end
+
+    it "user can delete their subscription" do
+      subscription = @user1.subscription
+      delete "/api/v1/users/#{@user1.id}/subscription/#{subscription.id}"
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      delete_response = JSON.parse(response.body, symbolize_names: true)
+      expect(delete_response[:data][:attributes][:id]).to eq(subscription.id)
+    end
+
+    it 'get all subscriptions' do
+      get "/api/v1/subscriptions"
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      sub_response = JSON.parse(response.body, symbolize_names: true)
+      expect(sub_response[:data].length).to eq(1)
+      expect(sub_response[:data].first[:attributes][:id]).to eq(@user1.subscription.id)
+    end
+
+    it 'can get subscription by id' do
+      get "/api/v1/subscriptions/#{@user1.subscription.id}"
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      
+      sub_response = JSON.parse(response.body, symbolize_names: true)
+      expect(sub_response[:data][:attributes][:id]).to eq(@user1.subscription.id)
+    end
+
+    it 'has error handling if subscription not found' do
+      get "/api/v1/subscriptions/9999999999"
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+      expect(item_response[:data][:attributes][:message]).to eq('Oops, record not found')
+    end
+  end
+end


### PR DESCRIPTION
## Description
Sets up crud endpoints for users, subscriptions, and items.
Here the Subscription controller is intended for user related endpoints and the Subscriptions controller is intended for the admins use. This also adds custom error handling at the controller level for missing params, passwords mismatching and records not found.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Notes
Right now there are no checks being performed to interact with the controller, a lot of these crud endpoints will require a user with an admin role which will be a later EPIC. Subscription will require a current_user as well which will be built out when I introduce jwt sessions into the project.
## Test Results
```
...........................................

Finished in 0.6454 seconds (files took 1.53 seconds to load)
43 examples, 0 failures
```