### PR TITLE
Recurring shipments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'fast_jsonapi'
 gem 'jwt_sessions'
 gem 'cloudinary'
 gem 'figaro'
+gem 'sidekiq'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'jwt_sessions'
 gem 'cloudinary'
 gem 'figaro'
 gem 'sidekiq'
+gem 'sidekiq-scheduler'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,10 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    e2mmap (0.1.0)
     erubi (1.9.0)
+    et-orbi (1.2.4)
+      tzinfo
     faker (2.13.0)
       i18n (>= 1.6, < 2)
     fast_jsonapi (1.5)
@@ -78,6 +81,9 @@ GEM
     ffi (1.13.1)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
+    fugit (1.3.9)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     http-accept (1.7.0)
@@ -120,6 +126,7 @@ GEM
       method_source (~> 1.0)
     public_suffix (4.0.6)
     puma (3.12.6)
+    raabro (1.4.0)
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -178,12 +185,21 @@ GEM
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
     ruby_dep (1.5.0)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
     sidekiq (6.1.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sidekiq-scheduler (3.0.1)
+      e2mmap
+      redis (>= 3, < 5)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 3)
+      thwait
+      tilt (>= 1.4.0)
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -201,6 +217,9 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    thwait (0.2.0)
+      e2mmap
+    tilt (2.0.10)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -236,6 +255,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers
   sidekiq
+  sidekiq-scheduler
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       rest-client
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
+    connection_pool (2.2.3)
     crass (1.0.6)
     diff-lcs (1.4.4)
     docile (1.3.2)
@@ -179,6 +180,10 @@ GEM
     ruby_dep (1.5.0)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -230,6 +235,7 @@ DEPENDENCIES
   redis (~> 4.0)
   rspec-rails
   shoulda-matchers
+  sidekiq
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,13 @@ class User < ApplicationRecord
     self.role ||= 1
   end
 
-  def self.get_users
-    User.where(role: 1)
+  class << self
+    def get_users
+      User.where(role: 1)
+    end
+
+    def users_with_subscriptions
+      User.joins(:subscription)
+    end
   end
 end

--- a/app/workers/shipment_worker.rb
+++ b/app/workers/shipment_worker.rb
@@ -1,0 +1,7 @@
+class ShipmentWorker
+  include Sidekiq::Worker
+
+  def perform(*args)
+    # Do something
+  end
+end

--- a/app/workers/shipment_worker.rb
+++ b/app/workers/shipment_worker.rb
@@ -2,6 +2,6 @@ class ShipmentWorker
   include Sidekiq::Worker
 
   def perform(*args)
-    # Do something
+    p User.all
   end
 end

--- a/app/workers/shipment_worker.rb
+++ b/app/workers/shipment_worker.rb
@@ -2,6 +2,14 @@ class ShipmentWorker
   include Sidekiq::Worker
 
   def perform(*args)
-    p User.all
+    five_days_later = 432000
+    delivery_date = Time.now + five_days_later
+    
+    User.users_with_subscriptions.each do |user|
+      user.subscription.shipments.create(
+        status: 0,
+        delivery_date: delivery_date.strftime('%m/%d/%y')
+      )
+    end
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:schedule:
+  add_shipment:
+    every: 10s
+    class: ShipmentWorker

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
 :schedule:
   add_shipment:
-    every: 10s
+    every: 24h
     class: ShipmentWorker

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe User do
       expect(user.role).to eq('user')
     end
 
-    it "should over ride default of 0 if passed in create" do
+    it "should over ride default of 1 if passed in create" do
       user_params = {
         email: "zach@gmail.com",
         name: "Zach H",
@@ -50,6 +50,40 @@ RSpec.describe User do
 
       admin = User.create(admin_params)
       expect(admin.role).to eq('admin')
+    end
+  end
+
+  describe "class methods" do
+    before(:each) do
+      user_params = {
+        email: "zach@gmail.com",
+        name: "Zach H",
+        password: "1234",
+        address: "499 Humboldt. Pl." 
+      }
+
+      @user = User.create(user_params)
+
+      @user2 = User.create!(
+        email: 'john@example.com',
+        name: 'John Wick',
+        address: '900 Victoria St.',
+        password: '1234',
+        password_confirmation: '1234',
+        city: "Denver",
+        state: "CO",
+        zip: "40000"
+      )
+      subscription_params = {
+          subscription_type: 0,
+          delivery_day: "Monday",
+          user: @user2
+        }
+      @subscription = Subscription.create!(subscription_params)
+    end
+
+    it ".users_with_subscriptions" do
+      expect(User.users_with_subscriptions).to eq([@user2])
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'sidekiq/testing'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production

--- a/spec/workers/shipment_worker_spec.rb
+++ b/spec/workers/shipment_worker_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+RSpec.describe ShipmentWorker, type: :worker do
+  before(:each) do
+    Sidekiq::Worker.clear_all
+
+    @user = User.create!(
+        email: 'john@example.com',
+        name: 'John Wick',
+        address: '900 Victoria St.',
+        password: '1234',
+        password_confirmation: '1234'
+      )
+    subscription_params = {
+        subscription_type: 0,
+        delivery_day: "Monday",
+        user: @user
+      }
+    @subscription = Subscription.create!(subscription_params)
+  end
+
+  it 'adds job to the queue' do
+    expect(ShipmentWorker.jobs.size).to eq(0)
+
+    ShipmentWorker.perform_async(@subscription)
+    expect(ShipmentWorker.jobs.size).to eq(1)
+  end
+end

--- a/spec/workers/shipment_worker_spec.rb
+++ b/spec/workers/shipment_worker_spec.rb
@@ -21,7 +21,12 @@ RSpec.describe ShipmentWorker, type: :worker do
   it 'adds job to the queue' do
     expect(ShipmentWorker.jobs.size).to eq(0)
 
-    ShipmentWorker.perform_async(@subscription)
+    ShipmentWorker.perform_async(@user)
     expect(ShipmentWorker.jobs.size).to eq(1)
+  end
+
+  it 'adds a shipment to the users subscription' do
+    ShipmentWorker.perform_async(@user)
+    
   end
 end

--- a/spec/workers/shipment_worker_spec.rb
+++ b/spec/workers/shipment_worker_spec.rb
@@ -1,4 +1,6 @@
 require 'rails_helper'
+require 'fugit'
+
 RSpec.describe ShipmentWorker, type: :worker do
   before(:each) do
     Sidekiq::Worker.clear_all
@@ -8,7 +10,10 @@ RSpec.describe ShipmentWorker, type: :worker do
         name: 'John Wick',
         address: '900 Victoria St.',
         password: '1234',
-        password_confirmation: '1234'
+        password_confirmation: '1234',
+        city: "Denver",
+        state: "CO",
+        zip: "40000"
       )
     subscription_params = {
         subscription_type: 0,
@@ -16,17 +21,35 @@ RSpec.describe ShipmentWorker, type: :worker do
         user: @user
       }
     @subscription = Subscription.create!(subscription_params)
+
+    @sidekiq_file = File.join(Rails.root, "config", "sidekiq.yml")
+    @schedule = YAML.load_file(@sidekiq_file)[:schedule]
+  end
+
+  it "cron syntax is correct" do
+    shipment_schedule = @schedule["add_shipment"]
+    cron = shipment_schedule["every"]
+    expect { Fugit.do_parse(cron) }.not_to raise_error
+  end
+
+  it "check that the worker class exists" do
+    shipment_schedule = @schedule["add_shipment"]
+    klass = shipment_schedule["class"]
+    expect { klass.constantize }.not_to raise_error
   end
 
   it 'adds job to the queue' do
     expect(ShipmentWorker.jobs.size).to eq(0)
 
-    ShipmentWorker.perform_async(@user)
+    ShipmentWorker.perform_async
     expect(ShipmentWorker.jobs.size).to eq(1)
   end
 
   it 'adds a shipment to the users subscription' do
-    ShipmentWorker.perform_async(@user)
-    
+    expect(@user.subscription.shipments.length).to eq(0)
+    shipment_worker = ShipmentWorker.new
+    shipment_worker.perform
+    user = User.last
+    expect(user.subscription.shipments.length).to eq(1)
   end
 end


### PR DESCRIPTION
## Description
This is the preliminary set up of sidekiq. I'm using a shipment worker class that will look for Users with subscriptions and then add a new shipment to their subscription every 24 hours. This PR also adds/configures sidekiq-scheduler as well as sidekiq.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Notes
Right now this functionality is incomplete in the sense that the worker will just create shipments every 24 hours. Next step is to change the 24 hours check to only check if there are Users whose subscription needs a new shipment and only create them for those users. I also have to take into account the differing types of subscriptions Weekly, Monthly and change that as well.
## Test Results
```
.............................................................................

Finished in 1.22 seconds (files took 1.82 seconds to load)
77 examples, 0 failures
```